### PR TITLE
fix version and revert back to slash_command API

### DIFF
--- a/discordbot.py
+++ b/discordbot.py
@@ -18,7 +18,8 @@ def send_graphql_request(repo_name):
         alwaysNil
       }}
     }}
-    """  
+    """
+    # print(body)  
     response = requests.post(url=url, json={"query": body}, headers={
         'Authorization': f'token {SG_TOKEN}' 
     })
@@ -29,10 +30,10 @@ def send_graphql_request(repo_name):
 intents = discord.Intents.default()
 intents.messages = True
 
-bot = Bot(command_prefix = '$', intents=intents)
+bot = Bot(command_prefix = 'embeddings', intents=intents)
 
 
-@bot.command(description="Create Embedding for Cody.")
+@bot.slash_command(description="Create Embedding for Cody.")
 @discord.option("name", description="Enter the public GitHub repo.")
 async def embedding(ctx: discord.ApplicationContext, repo_name: str):
     try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-py-cord
+py-cord==2.4.1
 requests
 asyncio
 urllib3==1.25.11


### PR DESCRIPTION
- pinned version py-cord to 2.4.1 
- reverted back to `slash_command` discord API

Tested with discord bot and works as expected when invoked `/embeddings github_url https://github.com/sourcegraph/sourcegraph` 

![Screenshot 2023-06-07 at 9 16 12 AM](https://github.com/sourcegraph/cody-embeddings-discord-bot/assets/6303227/119764f0-a8a2-4fce-be4c-1dcac5468279)