### PR TITLE
Untested: Switch to wolfi image + fix vulnerable dep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ ENV HTTP_HOST=0.0.0.0
 
 EXPOSE 8080
 
-CMD ["python", "discordbot.py"]
+ENTRYPOINT ["python", "discordbot.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ ENV HTTP_HOST=0.0.0.0
 
 EXPOSE 8080
 
-ENTRYPOINT ["python", "discordbot.py"]
+CMD ["discordbot.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/python:3.11-dev
+FROM cgr.dev/chainguard/python:3.11-dev@sha256:c7267ad0f84dd8b44fcea8962a0a97f44e719b703cf57321bff1576269a8043b
 
 COPY discordbot.py config.py requirements.txt . 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:3.11-slim@sha256:7d28177da146154adb077f7d71e21fdb9a7696128a7353b7db4cbb40c6e2d0ac
+FROM cgr.dev/chainguard/python:3.11-dev
 
 COPY discordbot.py config.py requirements.txt . 
 
 RUN pip install -r requirements.txt
- 
+
 ENV HTTP_PORT=8080
 ENV HTTP_HOST=0.0.0.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 py-cord==2.4.1
 requests
 asyncio
-urllib3==1.25.11
+urllib3==1.26.5
 aiohttp


### PR DESCRIPTION
Update the base image from `python:3.11-slim` to chainguard's wolfi-based python image. We need the `-dev` variant as the Dockerfile uses pip to install deps.

I haven't tested the image's bot functionality.

* Trivy before: 86 (UNKNOWN: 0, LOW: 65, MEDIUM: 2, HIGH: 18, CRITICAL: 1)
* Trivy after: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0) (though grype detects 1 vuln in `pip`)