### PR TITLE
Remove label from container as label is no longer public

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM cgr.dev/chainguard/python:3.11-dev@sha256:c7267ad0f84dd8b44fcea8962a0a97f44e719b703cf57321bff1576269a8043b
+# Pinned to python:3.11-dev
+FROM cgr.dev/chainguard/python@sha256:c7267ad0f84dd8b44fcea8962a0a97f44e719b703cf57321bff1576269a8043b
 
 COPY discordbot.py config.py requirements.txt .
 


### PR DESCRIPTION
After our contract with chainguard ends, we will only be able to use the `latest` label or pull by SHA. Updated base image to use SHA.

## Test plan

- Tested build locally